### PR TITLE
Replacing `print` with `print()` in prep for py3

### DIFF
--- a/snmachine/parametric_models.py
+++ b/snmachine/parametric_models.py
@@ -1,6 +1,7 @@
 """
 Module for parametric models for use in snfeatures module
 """
+from __future__ import print_function
 import numpy as np
 
 class NewlingModel:
@@ -46,7 +47,7 @@ class NewlingModel:
 
         #Fits a cubic spine between only two points given x and y input and their derivatives and evaluates it on x_eval
         if len(x)>2:
-            print 'this is only appropriate for 2 datapoints'
+            print('this is only appropriate for 2 datapoints')
             return 0
             
         x1, x2=x

--- a/snmachine/snclassifier.py
+++ b/snmachine/snclassifier.py
@@ -2,7 +2,7 @@
 Utility module mostly wrapping sklearn functionality and providing utility functions.
 """
 
-from __future__ import division
+from __future__ import division, print_function
 import numpy as np
 import matplotlib.pyplot as plt
 from sklearn import svm
@@ -26,7 +26,7 @@ try:
     from sklearn.neural_network import MLPClassifier
     choice_of_classifiers.append('neural_network')
 except ImportError:
-    print 'Neural networks not available in this version of scikit-learn. Neural networks are available from development version 0.18.'
+    print('Neural networks not available in this version of scikit-learn. Neural networks are available from development version 0.18.')
 
 def roc(pr, Yt, true_class=0):
     """
@@ -375,19 +375,17 @@ class OptimisedClassifier():
                 elif classifier=='multiple_classifier':
                     pass
                 else:
-                    print 'Requested classifier not recognised.' 
-                    print 'Choice of built-in classifiers:'
-                    print choice_of_classifiers
+                    print('Requested classifier not recognised.')
+                    print('Choice of built-in classifiers:')
+                    print(choice_of_classifiers)
                     sys.exit(0)
                     
             except TypeError:
                 #Gracefully catch errors of sending the wrong kwargs to the classifiers
-                print
-                print 'Error'
-                print 'One of the kwargs below:'
-                print kwargs.keys()
-                print 'Does not belong to classifier', classifier
-                print
+                print('Error')
+                print('One of the kwargs below:')
+                print(kwargs.keys())
+                print('Does not belong to classifier', classifier)
                 sys.exit(0)
             
                 
@@ -395,9 +393,8 @@ class OptimisedClassifier():
             #This is already some sklearn classifier or an object that behaves like one
             self.clf=classifier 
         
-        print 'Created classifier of type:'
-        print self.clf
-        print    
+        print('Created classifier of type:')
+        print(self.clf)
             
     
 
@@ -502,20 +499,16 @@ class OptimisedClassifier():
         
         self.clf.fit(X_train, y_train) #This actually does the grid search
         best_params=self.clf.best_params_
-        print 'Optimised parameters:', best_params
+        print('Optimised parameters:', best_params)
         
         for k in best_params.keys():
             #This is the safest way to check if something is a number
             try:
                 float(best_params[k])
                 if best_params[k]<=min(params[k]):
-                    print
-                    print 'WARNING: Lower boundary on parameter', k, 'may be too high. Optimum may not have been reached.'
-                    print
+                    print('WARNING: Lower boundary on parameter', k, 'may be too high. Optimum may not have been reached.')
                 elif best_params[k]>=max(params[k]):
-                    print
-                    print 'WARNING: Upper boundary on parameter', k, 'may be too low. Optimum may not have been reached.'
-                    print
+                    print('WARNING: Upper boundary on parameter', k, 'may be too low. Optimum may not have been reached.')
                 
             except (ValueError, TypeError):
                 pass #Ignore a parameter that isn't numerical
@@ -645,9 +638,9 @@ def run_pipeline(features,types,output_name='',columns=[],classifiers=['nb','knn
     classifier_objects={}
 
     if nprocesses>1 and return_classifier:
-        print "Due to limitations with python's multiprocessing module, classifier objects cannot be returned if " \
-              "multiple processors are used. Continuing serially..."
-        print
+        print("Due to limitations with python's multiprocessing module, classifier objects cannot be returned if " \
+              "multiple processors are used. Continuing serially...")
+        print('\n')
 
     if nprocesses>1 and not return_classifier:
         partial_func=partial(__call_classifier,X_train=X_train, y_train=y_train, X_test=X_test,
@@ -675,7 +668,7 @@ def run_pipeline(features,types,output_name='',columns=[],classifiers=['nb','knn
         fpr, tpr, auc=roc(probs, y_test, true_class=1)
         fom, thresh_fom=FoM(probs, y_test, true_class=1, full_output=False)
 
-        print 'Classifier', cls+':', 'AUC =', auc, 'FoM =', fom
+        print('Classifier', cls+':', 'AUC =', auc, 'FoM =', fom)
 
         if i==0:
             FPR=fpr
@@ -706,8 +699,7 @@ def run_pipeline(features,types,output_name='',columns=[],classifiers=['nb','knn
 
             np.savetxt(output_name+cls+'.auc',[auc])
 
-    print
-    print 'Time taken ', (time.time()-t1)/60., 'minutes'
+    print('\nTime taken ', (time.time()-t1)/60., 'minutes\n')
 
     if plot_roc_curve:
         plot_roc(FPR, TPR, AUC, labels=classifiers,label_size=16,tick_size=12,line_width=1.5)

--- a/snmachine/sndata.py
+++ b/snmachine/sndata.py
@@ -2,7 +2,7 @@
 Module containing Dataset classes. These read in data from various sources and turns the light curves into astropy tables that
 can be read by the rest of the code.
 """
-from __future__ import division
+from __future__ import division, print_function
 import numpy as np
 import matplotlib.pyplot as plt
 from astropy.table import Table, Column
@@ -104,7 +104,7 @@ class Dataset:
         #Get all the data as a list of astropy tables (this should not be memory intensive, even for large numbers of light curves)
         self.data={}
         invalid=0 #Some objects may have empty data
-        print 'Reading data...'
+        print('Reading data...')
         for i in range(len(self.object_names)):
             lc=self.get_lightcurve(self.object_names[i])
             if len(lc['mjd']>0):
@@ -112,8 +112,8 @@ class Dataset:
             else:
                 invalid+=1
         if invalid>0:
-            print '%d objects were invalid and not added to the dataset.' %invalid
-        print '%d objects read into memory.' %len(self.data)
+            print('%d objects were invalid and not added to the dataset.' %invalid)
+        print('%d objects read into memory.' %len(self.data))
         #We create an optional model set which can be set by whatever feature class used
         self.models={}
         
@@ -142,7 +142,7 @@ class Dataset:
             try:
                 object_names= names[subset]
             except IndexError:
-                print 'Invalid subset provided'
+                print('Invalid subset provided')
                 sys.exit()
                 
         return np.sort(object_names)
@@ -294,10 +294,10 @@ class Dataset:
         args : list, optional
             Whatever arguments fit_sn requires
         """
-        print 'Fitting supernova models...'
+        print('Fitting supernova models...')
         for obj in self.object_names:
             self.models[obj]=fit_sn(self.data[obj], *args)
-        print 'Models fitted.'
+        print('Models fitted.')
     
     def plot_lc(self, fname, plot_model=True, title=True, loc='best'):
         """Public function to plot a single light curve.
@@ -415,16 +415,14 @@ class Dataset:
             redshifts[i]=lc.meta['z']
             types[i]=lc.meta['type']
             
-        print
-        print 'Total number of SNe: %d' %(N)
-        print
+        print('Total number of SNe: %d' %(N))
         ks=self.get_types().keys()
         ks.sort()
         for k in ks:
             nk=len(np.where(types==k)[0])
-            print 'Number of %s: %d (%0.2f%%)' %(self.get_types()[k],nk ,nk/N*100)
+            print('Number of %s: %d (%0.2f%%)' %(self.get_types()[k],nk ,nk/N*100))
         nk=len(np.where(types==-9)[0])
-        print 'Number of unknown: %d (%0.2f%%)' %(nk ,nk/N*100)
+        print('Number of unknown: %d (%0.2f%%)' %(nk ,nk/N*100))
         
         if plot_redshifts==True:
             plt.hist(redshifts[redshifts!=-9], 30, facecolor='#0057f6')
@@ -552,7 +550,7 @@ class OpsimDataset(Dataset):
         self.object_names=[]
         
         invalid=0 #Some objects may have empty data
-        print 'Reading data...'
+        print('Reading data...')
         
         for i in range(len(all_data)):
             snid=all_data[i].meta['SNID']
@@ -564,9 +562,9 @@ class OpsimDataset(Dataset):
                 else:
                     invalid+=1
         if invalid>0:
-            print '%d objects were invalid and not added to the dataset.' %invalid
+            print('%d objects were invalid and not added to the dataset.' %invalid)
         self.object_names=np.array(self.object_names, dtype='str')
-        print '%d objects read into memory.' %len(self.data)
+        print('%d objects read into memory.' %len(self.data))
         
         
     def get_lightcurve(self, tab):
@@ -629,7 +627,7 @@ class SDSS_Data(Dataset):
         #Get all the data as a list of astropy tables (this should not be memory intensive, even for large numbers of light curves)
         self.data={}
         invalid=0 #Some objects may have empty data
-        print 'Reading data...'
+        print('Reading data...')
         for i in range(len(self.object_names)):
             lc=self.get_lightcurve(self.object_names[i])
             if len(lc['mjd']>0):
@@ -637,8 +635,8 @@ class SDSS_Data(Dataset):
             else:
                 invalid+=1
         if invalid>0:
-            print '%d objects were invalid and not added to the dataset.' %invalid
-        print '%d objects read into memory.' %len(self.data)
+            print('%d objects were invalid and not added to the dataset.' %invalid)
+        print('%d objects read into memory.' %len(self.data))
         #We create an optional model set which can be set by whatever feature class used
         self.models={}
 
@@ -725,7 +723,7 @@ class SDSS_Data(Dataset):
             elif classification == 'II' or classification == 'SNII':
                 SN = [SN[i] for i in range(len(SN)) if classes[i] == 'SNII']
             else:
-                print 'Invalid classification requested.'
+                print('Invalid classification requested.')
                 sys.exit()
 
         return SN
@@ -773,7 +771,7 @@ class SDSS_Data(Dataset):
             elif classification == 'II' or classification == 'SNII':
                 SN = [SN[i] for i in range(len(SN)) if classes[i] == 'pSNII' or classes[i] == 'zSNII']
             else:
-                print 'Invalid classification requested.'
+                print('Invalid classification requested.')
                 sys.exit()
 
         return SN
@@ -812,7 +810,7 @@ class SDSS_Data(Dataset):
             try:
                 return names[subset]
             except IndexError:
-                print 'Invalid subset provided'
+                print('Invalid subset provided')
 
 
     def get_info(self,flname):
@@ -965,11 +963,11 @@ class SDSS_Simulations(Dataset):
         #Get all the data as a list of astropy tables (this should not be memory intensive, even for large numbers of light curves)
         self.data={}
         invalid=0 #Some objects may have empty data
-        print 'Reading data..'
+        print('Reading data..')
         (self.data, invalid) = self.get_data(subset, subset_length, classification)
         if invalid>0:
-            print '%d objects were invalid and not added to the dataset.' %invalid
-        print '%d objects read into memory.' %len(self.data)
+            print('%d objects were invalid and not added to the dataset.' %invalid)
+        print('%d objects read into memory.' %len(self.data))
         self.object_names = self.data.keys()
         #We create an optional model set which can be set by whatever feature class used
         self.models={}
@@ -1030,7 +1028,7 @@ class SDSS_Simulations(Dataset):
                 else:
                     invalid+=1
         else:
-            print 'Invalid classification requested'
+            print('Invalid classification requested')
             sys.exit()
         
         # allow user to request entirely spectroscopic data or photometric data

--- a/snmachine/tsne_plot.py
+++ b/snmachine/tsne_plot.py
@@ -2,7 +2,7 @@
 Utility script for making nice t-SNE plots (https://lvdmaaten.github.io/tsne/)
 """
 
-from __future__ import division
+from __future__ import division, print_function
 import matplotlib.pyplot as plt
 from sklearn.manifold import TSNE
 import numpy as np


### PR DESCRIPTION
- Added `print_function` import to the main modules to get python to complain.
- Manually changed print statements to print(
	modified:   snmachine/snclassifier.py
	modified:   snmachine/sndata.py
	modified:   snmachine/snfeatures.py
	modified:   snmachine/parametric_models.py
	modified:   snmachine/tsne_plot.py
- Reordered imports, but left moving to absolute imports for another
  step.
- Checked that tests pass. 

Fixes #26 