### PR TITLE
Added line to change plt backend in sndata.py

### DIFF
--- a/snmachine/sndata.py
+++ b/snmachine/sndata.py
@@ -10,6 +10,7 @@ if not 'DISPLAY' in os.environ:
     import matplotlib
     matplotlib.use('Agg')
 import matplotlib.pyplot as plt
+plt.switch_backend('tkagg')
 from astropy.table import Table, Column
 from astropy.io import fits
 import sys, sncosmo


### PR DESCRIPTION
I have been writing my own script to run snmachine, in a similar way to how the jupyter notebook example is set out, although kept having the problem of my plots not showing. After doing some research, it appeared to be a mac problem to do with the backend of matplotlib. I found that adding this line to sndata.py (as well as in my own script which imports sndata.py like the jn example), which changes matplotlib's backend to TkAgg, makes the plots visible. snmachine now works as it is supposed to.