### PR TITLE
Merge `docs` with `gh-pages` branch so we can close `docs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # snmachine
 
-Welcome to version 1.0 of `snmachine`! As described in [Lochner et al. (2016)](https://arxiv.org/abs/1603.00882), this is a flexible python library for reading in photometric supernova light curves, extracting useful features from them and subsequently performing supervised machine learning to classify supernovae based on their light curves. The library is also flexible enough to easily extend to general transient classification.
+Welcome to version 1.0 of `snmachine`! As described in ([Lochner et al. (2016)](https://arxiv.org/abs/1603.00882)), this is a flexible python library for reading in photometric supernova light curves, extracting useful features from them and subsequently performing supervised machine learning to classify supernovae based on their light curves. The library is also flexible enough to easily extend to general transient classification.
+
+Up-to-date documentation of `snmachine` can be found via the following Github Pages link.
+
+[Online Documentation](https://lsstdesc.github.io/snmachine/)
 
 ## Usage Policy
 
@@ -17,114 +21,11 @@ We welcome developers! Simply fork it into your own private repository and submi
 
 ## Citation
 
-If you use snmachine in your work please cite ([BibTex])(http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2016ApJS..225...31L&data_type=BIBTEX&db_key=AST&nocookieset=1):
+If you use snmachine in your work please cite ([BibTex](http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2016ApJS..225...31L&data_type=BIBTEX&db_key=AST&nocookieset=1)):
 Lochner, M., McEwen, J., Peiris, H., Lahav, O., Winter, M. (2016) “Photometric Supernova Classification with Machine Learning”, The Astrophysical Journal Supplement Series, 225, 31
 
 ## Installation
 
 snmachine is now compatible with Python2 and Python3.
 
-There are two possible ways to set up snmachine:
-
-### Using conda
-
-By far the easiest way to install snmachine is to use anaconda.
-
-1) Install anaconda if you don't already have it (https://www.continuum.io/downloads)
-
-2) Create a new anaconda environment by type (inside the snmachine folder):
-
-`conda env create --name snmachine --file environment.yml`
-
-3) Activate the environment by typing:
-
-`source activate snmachine`
-
-**Note: If you have tsch instead of bash this will not work!**
-
-A simple workaround is to manually edit your PATH environment variable to point to the new anaconda environment:
-
-`setenv PATH <your path to anaconda>/envs/snmachine/bin/:$PATH`
-
-4) Install snmachine by typing:
-
-`python setup.py install`
-
-or if you're developing
-
-`python setup.py develop`
-
-### Manual dependency installation
-
-If you don't want to use an conda environment, snmachine requires the following packages (all of which are on either conda or pip):
-
-dependencies:
-  - astropy>=1.1.2
-  - jupyter>=1.0.0
-  - matplotlib=1.5.1
-  - numpy=1.11.0
-  - scikit-learn=0.18.1
-  - scipy>=0.17.0
-  - emcee>=2.1.0 [pip]
-  - iminuit>=1.2 [pip]
-  - numpydoc>=0.6.0 [pip]
-  - pywavelets>=0.4.0 [pip]
-  - sncosmo>=1.3.0 [pip]
-  - nose>=1.3.7 [pip]
-  - george>=0.3.0 [pip]
-  - future>=0.16 [pip]
-  - sphinx_rtd_theme>=0.2.4 [pip]
-
-
-### Installation caveats
-
-1) `snmachine` has the ability to use nested sampling for some of the parameter estimates, which we have found to give much more reliable fits than least squares. However this depends on `pymultinest` (https://github.com/JohannesBuchner/PyMultiNest) being installed separately, since it requires manual compiling of Fortran code (but not it's not a particularly difficult one).
-
-2) If you want to use neural networks, these are currently only available in the development version of scikit-learn (version 0.18). You will also need to install that separately to enable neural networks (see http://scikit-learn.org/stable/developers/contributing.html#git-repo).
-
-
-## Documentation
-
-snmachine has complete docstrings for all functions and classes. These can be compiled into html documentation by typing:
-
-`make html`
-
-in the `docs` folder.
-
-## Examples
-
-The folder `examples` contains an example jupyter notebook. Start the notebook from the `examples` directory by typing:
-
-`jupyter notebook example_spcc.ipynb`
-
-Execute each cell block using "shift-enter". A subset of simulated DES data from the supernova photometric classification challenge is provided to illustrate the code.
-
-## Unit Tests
-
-snmachine comes with a suite of unit tests, which allow you to check whether the software has been set up correctly and is working properly. Please navigate to the test folder to run tests.
-
-
-## `snmachine`on NERSC
-
-To run `snmachine` on NERSC, set your shell to bash shell, and please run the following from the command line:
-
-```
-export PATH=/global/projecta/projectdirs/lsst/groups/SN/miniconda3/bin:$PATH
-```
-
-Then to use `snmachine` any time all that is needed is to activate the environment using,
-
-```
-module load python
-source activate snmachine
-```
-
-### `snmachine` on Jupyter @ NERSC
-
-Prior to accessing the Jupyter interface, either create a `.condarc` file (if you do not have already) with the following lines:
-
-```
-envs_dirs:
- - /global/projecta/projectdirs/lsst/groups/SN/miniconda3/envs
-```
-or append this to your exisitng `.condarc`file. Be sure to access Jupyter via https://jupyter-dev.nersc.gov/ and not the Jupyter-Hub via 'MyNERSC' pages. Then, when prompted or accessing the notebook file, choose the `Python [conda env:snmachine]` kernel. This can be found under Kernel tab in the top menu bar. 
+The installation is detailed in the online documentation. ([Install Guide](https://lsstdesc.github.io/snmachine/install.html)):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@ snmachine
 .. image:: https://img.shields.io/badge/GitHub-LSSTDESC%2Fsnmachine-blue.svg?style=flat
     :target: https://github.com/LSSTDESC/snmachine
 
-Welcome to version 1.0 of snmachine! As described in Lochner et al. (2016),
+Welcome to version 1.0 of snmachine! As described in Lochner et al. `(2016) <https://arxiv.org/abs/1603.00882>`_,
 this is a flexible python library for reading in photometric supernova light
 curves, extracting useful features from them and subsequently performing
 supervised machine learning to classify supernovae based on their light curves.
@@ -19,7 +19,7 @@ Usage Policy
 
 This code is made available within the LSST DESC Collaboration. snmachine was
 developed within the DESC, using DESC resources, and so meets the criteria given
-in the DESC Publication Policy for being a “DESC product” (DESC Publication Policy).
+in the DESC Publication Policy for being a “DESC product” (`DESC Publication Policy <http://lsstdesc.org/sites/default/files/LSST_DESC_Publication_Policy.pdf>`_).
 We are aware that the codebase might be useful within other collaborations and
 welcome requests for access to the code for non-DESC use. If you wish to use the
 code outside DESC please submit your request here.
@@ -27,8 +27,7 @@ code outside DESC please submit your request here.
 Citation
 ========
 
-If you use snmachine in your work please cite (`BibTex
-<http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2016ApJS..225...31L&data_type=BIBTEX&db_key=AST&nocookieset=1)>`_.)
+If you use snmachine in your work please cite (`BibTex <http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2016ApJS..225...31L&data_type=BIBTEX&db_key=AST&nocookieset=1>`_.)
 Lochner, M., McEwen, J., Peiris, H., Lahav, O., Winter, M. (2016)
 “Photometric Supernova Classification with Machine Learning”,
 The Astrophysical Journal Supplement Series, 225, 31

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -58,12 +58,8 @@ Installation Caveats
 
 snmachine has the ability to use nested sampling for some of the parameter
 estimates, which we have found to give much more reliable fits than least
-squares. However this depends on pymultinest
-(https://github.com/JohannesBuchner/PyMultiNest) being installed separately,
+squares. However this depends on `pymultinest <https://github.com/JohannesBuchner/PyMultiNest>`_ being installed separately,
 since it requires manual compiling of Fortran code (but not it's not a
 particularly difficult one).
 
-If you want to use neural networks, these are currently only available in the
-development version of scikit-learn (version 0.18). You will also need to
-install that separately to enable neural networks
-(see http://scikit-learn.org/stable/developers/contributing.html#git-repo).
+If you want to use neural networks, these are available in newer versions of scikit-learn (version >= 0.18).

--- a/docs/parallel.rst
+++ b/docs/parallel.rst
@@ -1,3 +1,29 @@
-*******************
-Running in Parallel
-*******************
+*********************************
+Running on Clusters / in Parallel
+*********************************
+
+`snmachine` @ NERSC
+===================
+
+To run `snmachine` on NERSC first open an ssh connection to NERSC, set your shell to bash shell, and run the following from the command line:
+
+``export PATH=/global/projecta/projectdirs/lsst/groups/SN/miniconda3/bin:$PATH``
+
+Then to use `snmachine` any time all that is needed is to activate the environment using,::
+
+    module load python
+    source activate snmachine
+
+
+Setting up `snmachine` on Jupyter @ NERSC
+-----------------------------------------
+
+Prior to accessing the Jupyter interface, either create a ``.condarc`` file (if you do not have already) with the following lines::
+
+    envs_dirs:
+    - /global/projecta/projectdirs/lsst/groups/SN/miniconda3/envs
+
+or append this to your existing ``.condarc`` file. Be sure to access Jupyter via the `Jupyter-Dev hub <https://jupyter-dev.nersc.gov/>`_ , and not the Jupyter-Hub via 'MyNERSC' pages. Then, when prompted or accessing the notebook file, choose the ``Python [conda env:snmachine]``` kernel. This can be found under Kernel tab in the top menu bar. Now `snmachine` will be accessible through your Jupyter notebook.
+
+Running jobs @ NERSC
+--------------------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -2,25 +2,31 @@
 Quick Start
 ***********
 
-
-`snmachine` on NERSC
-====================
-To run `snmachine` on NERSC first open an ssh connection to NERSC, set your shell to bash shell, and run the following from the command line:
-
-``export PATH=/global/projecta/projectdirs/lsst/groups/SN/miniconda3/bin:$PATH``
-
-Then to use `snmachine` any time all that is needed is to activate the environment using,::
-
-    module load python
-    source activate snmachine
+First, if you are using `snmachine` on your own machine, please see the installation steps outlined in :doc:`install`.
 
 
-`snmachine` on Jupyter @ NERSC
-------------------------------
+Examples
+========
 
-Prior to accessing the Jupyter interface, either create a ``.condarc`` file (if you do not have already) with the following lines::
+To get a feel for running `snmachine` and to understand it's uses, the best place to start are the jupyter notebooks. These are contained in the folder `examples`, which you can also view on Github, `Getting Started Notebook <https://github.com/LSSTDESC/snmachine/blob/master/examples/example_spcc.ipynb>`_. You can also run this yourself. Start the notebook from the `examples` directory by typing,::
 
-    envs_dirs:
-    - /global/projecta/projectdirs/lsst/groups/SN/miniconda3/envs
+    jupyter notebook example_spcc.ipynb
 
-or append this to your existing ``.condarc`` file. Be sure to access Jupyter via the `Jupyter-Dev hub <https://jupyter-dev.nersc.gov/>`_ , and not the Jupyter-Hub via 'MyNERSC' pages. Then, when prompted or accessing the notebook file, choose the ``Python [conda env:snmachine]``` kernel. This can be found under Kernel tab in the top menu bar. Now `snmachine` will be accessible through your Jupyter notebook.
+Execute each cell block using "shift-enter". A subset of simulated DES data from the supernova photometric classification challenge is provided to illustrate the code.
+
+Unit tests
+==========
+
+Also, great way to check your installation of snmachine is to run the suite of unit tests. These allow you to check whether the software has been set up correctly and that each step is working properly. Please navigate to the `test` folder to run tests using the syntax,::
+
+    pytest *.py
+
+If you would like to run a subset of tests you can run the command,::
+
+    pytest *.py -m 'slow'
+
+to run the tests that are the most cpu-intensive. Or conversely,::
+
+    pytest *.py -m 'not slow'
+
+to run the tests of the basic functionality of `snmachine`.


### PR DESCRIPTION
Currently we have two documentation branches running around. It would be good to consolidate this into one branch. I have concluded that it would best that the remaining branch be the `gh-pages` branch as this will always automatically populate to the GithubPages site without any fiddling with settings. 

As there are some commits that contain information we want on `gh-pages` I propose we merge `docs` into `gh-pages` and then remove the docs branch. 