### PR TITLE
Update syntax for notebook image

### DIFF
--- a/examples/example_spcc.ipynb
+++ b/examples/example_spcc.ipynb
@@ -22,7 +22,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img src=\"pipeline.png\" width=600>"
+    "<img src=\"pipeline.png\" width=\"600\">"
    ]
   },
   {


### PR DESCRIPTION
This fix should render the pipeline image on github now. Changed `width=600` to `width="600"` in the image include line.

closes #49 