### PR TITLE
Issue/102/add metadata property

### DIFF
--- a/snmachine/sndata.py
+++ b/snmachine/sndata.py
@@ -1401,7 +1401,7 @@ class PlasticcData(EmptyDataset):
         if mix is True:
             self.mix()
 
-    def set_data(self, folder, data_file, cut_non_detections=True):
+    def set_data(self, folder, data_file, cut_non_detections=False):
         """Reads in simulated data and saves it.
         
         The data is saved into the `data` method from EmptyDataset.
@@ -1412,8 +1412,8 @@ class PlasticcData(EmptyDataset):
             Folder where simulations are located
         data_file : str or list-like
             .csv file of object lightcurves
-        cut_non_detections : bool, optional
-            If True, then we discard all nondetections and retain only detections. If False, we retain all.
+        cut_non_detections : boolean, optional
+            Default False. If True, cuts out nondetections, retaining only detections.
         """
         print('Reading data...')
         time_start_reading = time.time()
@@ -1478,9 +1478,7 @@ class PlasticcData(EmptyDataset):
         folder : str
             Folder where simulations are located
         data_file : str or list-like
-            .csv file of object lightcurves
-        cut_non_detections : bool, optional
-            If True, then we discard all nondetections and retain only detections. If False, we retain all.
+            .csv file of objects metadata
         """
         print('Reading metadata...')
         time_start_reading = time.time()


### PR DESCRIPTION
I actually didn't put metadata as a property.

This changes a lot of the `PlasticcData` class but it should be mostly backwards compatible.

After playing around with this, I think the user should not be able to change `dataset.object_names` nor `dataset.metadata`. What do you think about this?

I left 3 comments on the data. Two of them are because I wrote functions that could be `decorators`. I don't know how to do it or if they are useful as `decorators` but they seem to be fit. Do you think I should change them, or are they ok the way they are?

The last comment is addressed at @cnsetzer: Why do you use this code to print the evolution and not something simpler that only prints every 10%?
```
percent_to_print = pow(10, -int(np.log10(number_objs)/2))
if int(math.fmod(obj_ordinal, number_objs*percent_to_print)) == 0:
    print('{}%'.format(int(obj_ordinal/(number_objs*0.01))))
```