### PR TITLE
Moving away from manually updated version.py file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ class ExtractExampleData(install):
 
 setup(
     name='snmachine',
-    version=__version__,
     use_scm_version = {"root": ".", "relative_to": __file__},
     setup_requires=['setuptools_scm'],
     packages=['snmachine', 'gapp', 'gapp.covfunctions', 'utils'],

--- a/snmachine/__init__.py
+++ b/snmachine/__init__.py
@@ -1,8 +1,10 @@
-from __future__ import absolute_import
+from pkg_resources import get_distribution, DistributionNotFound
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    __version__ = 'unknown.dev'
+
 import os
-
-from .version import version as __version__
-
 here = __file__
 basedir = os.path.split(here)[0]
 example_data = os.path.join(basedir, 'example_data')

--- a/snmachine/version.py
+++ b/snmachine/version.py
@@ -1,9 +1,0 @@
-"""
-This file is has been inspired by sunpy/sunpy/version.py
-It will indentify which version is install by the user
-"""
-from pkg_resources import get_distribution, DistributionNotFound
-try:
-    version = get_distribution("snmachine").version
-except DistributionNotFound:
-    version = 'unknown.dev'


### PR DESCRIPTION
Removal of `packagedir` option due to error
```
UserWarning: Unknown distribution option: 'packagedir'
```
Removal of `cat` command that is not required

Addition of:
```
    use_scm_version = {"root": ".", "relative_to": __file__},
    setup_requires=['setuptools_scm'],
```
To allow for use of 'setuptools_scm'

Fixes #159 