### PR TITLE
Provide fallback for undetected tag versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ import tarfile
 
 
 PACKAGENAME = 'snmachine'
+__FALLBACK_VERSION__ = '1.5'
 
 class ExtractExampleData(install):
     """Post-installation data extraction."""
@@ -35,8 +36,11 @@ class ExtractExampleData(install):
 
 setup(
     name='snmachine',
-    use_scm_version = {"root": ".", "relative_to": __file__},
-    setup_requires=['setuptools_scm'],
+    use_scm_version={
+        "root": ".",
+        "relative_to": __file__,
+        "fallback_version": __FALLBACK_VERSION__},
+    setup_requires=['setuptools_scm>=3.2.0'],
     packages=['snmachine', 'gapp', 'gapp.covfunctions', 'utils'],
     include_package_data=True,
     package_data={'snmachine': ['example_data/SPCC_SUBSET.tar.gz', 'example_data/output_spcc_no_z/features/*.dat', 'example_data/example_data_for_tests.pckl']},


### PR DESCRIPTION
Fixes #188 

Using the `fallback_version` option found in [`setuptools_scm>=3.2.0`](https://github.com/pypa/setuptools_scm/pull/327/files) one can now provide a "fallback version" that can be used in case of no VCS being found. This may occur from downloading of tarballs or in the case in which it was discovered to be a bug; when one adds the repo as a submodule using `git submodule add git@github.com:LSSTDESC/snmachine.git`

Problem discussed in https://github.com/pypa/setuptools_scm/issues/96 and https://github.com/pypa/pip/issues/3908 with using submodules/pip in relation to this problem.

To test/explore locally: `SETUPTOOLS_SCM_DEBUG=1 pip install -vvv .`