### PR TITLE
Replace testpypi with pypi

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -20,8 +20,8 @@ jobs:
     - name: Build and publish
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TESTPYPI_API_TOKEN }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
         python setup.py sdist bdist_wheel
-        twine upload --repository testpypi dist/*
+        twine upload dist/*
  


### PR DESCRIPTION
We might be ready to use PyPI after testing with testpypi.  I pip installed 2.0.0.dev0 from testpypi at NERSC and used it as part of the `desc-python` installation.  I ran through the 7 notebooks in `snmachine/examples`.  No major problems.  I see a consistent warning about pymultinest, which seems to be optional (see below).  Otherwise I think this is all set.  I've updated to GH action workflow to upload to PyPI - so the next tag on this repo will make a release on PyPI.  Once that is done, I can add `snmachine` to desc-python.

```
No module named 'pymultinest'

                PyMultinest not found. If you would like to use, please install
                Mulitnest with 'sh install/multinest_install.sh; source
                install/setup.sh'
 ```

**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): _put link here_

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)


## What changes were proposed in this pull request?

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

How is the issue this PR is referenced against solved with this PR?

## How was this patch tested?

## Final Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I am up to date with `dev` branch of `snmachine` at the time of this PR
<!-- Assuming you are working from the guidelines outlined in CONTRIBUTING.md,
this can be achieve with `git pull --rebase upstream dev`

If this reveals a myriad of conflicts, one can run: `git rebase --abort` and
then one can submit a PR without checking the above box.

If you would like assistance with this, people contact one of the core developers
of snmachine for help-->
