### PR TITLE
allow more recent versions of sncosmo

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
     - numpydoc>=0.6.0
     - pytest-remotedata>=0.3.1
     - pywavelets>=0.4.0
-    - sncosmo==2.1.0
+    - sncosmo>=2.1.0
     - nose>=1.3.7
     - future>=0.16
     - pyyaml>=3.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ pandas>=0.23.0
 pyyaml>=3.13
 pywavelets>=0.4.0
 scipy>=0.17.0
-sncosmo==2.1.0
+sncosmo>=2.1.0

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
                       'iminuit',
                       'pandas>=0.23.0',
                       'pywavelets>=0.4.0',
-                      'sncosmo==2.1.0',
+                      'sncosmo>=2.1.0',
                       'nose>=1.3.7',
                       'future>=0.16',
                       'pyyaml>=3.13',


### PR DESCRIPTION
Fixes #265 

## Type of change
Update sncosmo constraint to allow versions > 2.1.0.  Hoping this update can be deploy to the version of snmachine availble on PyPI so that we can use it in td_env.

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What changes were proposed in this pull request?

Allow sncosmo>=2.1.0

How is the issue this PR is referenced against solved with this PR?

Updated version constraint on sncosmo to allow versions greater than 2.1.0 in environment.yml, requirements.txt, setup.py.

## How was this patch tested?

Installed snmachine in new conda environment defined using requirements.txt.
This update is already on the dev branch

## Final Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I am up to date with `dev` branch of `snmachine` at the time of this PR
<!-- Assuming you are working from the guidelines outlined in CONTRIBUTING.md,
this can be achieve with `git pull --rebase upstream dev`

If this reveals a myriad of conflicts, one can run: `git rebase --abort` and
then one can submit a PR without checking the above box.

If you would like assistance with this, people contact one of the core developers
of snmachine for help-->
